### PR TITLE
feat: add translate and check-and-commit Claude skills

### DIFF
--- a/.claude/skills/check-and-commit/SKILL.md
+++ b/.claude/skills/check-and-commit/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: check-and-commit
+description: Pre-commit verification gate — runs validation gates in order (biome if available, typecheck, and /translate to fill missing i18n .po strings when UI/locale files changed), fixes straightforward failures, then commits the specific files with a conventional message. Use after making changes when the work should be committed. Commits only when every gate is green; pushes only if the branch already tracks a remote or the user asked.
+---
+
+# check-and-commit — verification gate, then commit
+
+Run the gates in order, fix what's mechanically fixable, and commit only when
+everything is green. This skill is the only place in the workflow that commits.
+
+**Announce at start:** "Using the check-and-commit skill — running the gates,
+then committing."
+
+## Step 1: Identify what changed
+
+```bash
+git status --porcelain
+git diff --name-only HEAD   # staged + unstaged vs HEAD — the full change set
+```
+
+Derive every flag below from `git diff --name-only HEAD` (all changes vs the last
+commit). Plain `git diff --name-only` omits already-staged files. From the changed
+paths, derive:
+
+- `I18N_RELEVANT` — the diff adds/edits UI source that can introduce new
+  translatable strings (`app/**/*.tsx`, `app/**/*.ts`) **or** touches any
+  `locales/**/*.po`. When true, Gate 3 (i18n) fills missing translations so they
+  ship in this same commit.
+- whether any file is **outside** the intended change (leftover debug file,
+  unrelated edit). If yes → exclude it from staging and mention it in the report.
+
+## Step 2: Run the gates in order
+
+Stop on failure, apply the fix policy (Step 3), re-run the failed gate.
+
+```bash
+# Gate 1 — typecheck
+npx tsc --noEmit
+
+# Gate 2 — build (verify the site builds clean)
+npm run build
+```
+
+### Gate 3 — i18n translations (only if `I18N_RELEVANT`)
+
+Run **last**, after the code gates are green — so no Haiku translation effort is
+spent on a commit that would fail typecheck/build. Fill missing `.po`
+translations by invoking the **translate skill** (`/translate`), not by hand:
+
+- Invoke `/translate`. It refreshes catalogs (`lingui:extract`), fans missing
+  `msgstr` out to Haiku subagents, merges deterministically — see
+  `.claude/skills/translate/SKILL.md` for the full loop.
+- If it reports `NOTHING_TO_TRANSLATE` → mark gate SKIP and continue.
+- Otherwise it fills `locales/**/*.po`. Treat the gate as PASS only when
+  `/translate` finishes with `Remaining ... : 0`. If it stops with a residual
+  after its 3-round cap → **STOP, report BLOCKED**.
+- The filled `.po` files are part of this change — add them explicitly in Step 4.
+  `/translate` removes its own `.claude/scratch/translate/` scratch; never stage that.
+
+## Step 3: Fix policy
+
+| Failure | Action |
+|---------|--------|
+| Type error caused by this change | Fix the code, re-run |
+| Build error caused by this change | Fix the code, re-run |
+| Pre-existing failure, unrelated to this change | Note in report; don't block, don't fix |
+| Anything unclear or still failing after **2** fix attempts | STOP — report BLOCKED |
+
+"Pre-existing" must be proven, not assumed: the failing file is untouched by this
+diff, or the same failure reproduces on the merge-base.
+
+Red flags — thinking any of these means the gate is being weakened; STOP:
+
+- "I'll run the gates once at the end instead of in order"
+- "`git add -A` is faster"
+- "that failure is probably pre-existing" (prove it)
+- "the gate is flaky, I'll just retry until it passes"
+
+## Step 4: Commit
+
+Only when all applicable gates pass:
+
+```bash
+git add <each changed file, listed explicitly>   # NEVER `git add -A` or `git add .`
+git commit -m "<type>(<scope>): <description>"
+```
+
+- Types: `fix`, `feat`, `chore`, `refactor`, `test`, `docs`.
+- Staging is explicit because worktrees can accumulate runtime files that must
+  never be committed.
+- **Push only if** the branch already tracks a remote (`git rev-parse
+  --abbrev-ref @{upstream}` succeeds) **or** the user asked. Otherwise leave
+  the commit local and say so.
+
+## Step 5: Report
+
+```markdown
+## Check & Commit Report
+**Result:** COMMITTED | BLOCKED
+
+| Gate | Result | Notes |
+|------|--------|-------|
+| typecheck | PASS / SKIP | |
+| build | PASS / SKIP | |
+| i18n (/translate) | PASS / SKIP | <N filled across locales, or "no missing"> |
+
+**Commit:** `<sha>` — `<message>`  ·  **Pushed:** yes/no
+**Excluded from staging:** <files left uncommitted and why, or "none">
+```
+
+If BLOCKED: name the gate, the concise error, and what was attempted.

--- a/.claude/skills/translate/SKILL.md
+++ b/.claude/skills/translate/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: translate
+description: Fill missing i18n translations in the Lingui .po catalogs cheaply — extract every empty msgstr, fan out chunked jobs to Haiku subagents (model override, not the main model), merge results back deterministically, and verify zero remain. Produces filled locales/*/*.po. Use when asked to translate/fill missing translations, or after adding new UI strings. Do not use to add or mark new strings (that is lingui:extract in code) or to change the locale list.
+---
+
+# translate — fill missing .po translations with a cheap model
+
+Replaces `npm run translate` (which would run every string through the main model).
+Instead: a deterministic script finds every empty `msgstr`, chunks them into
+jobs, **Haiku subagents** translate the chunks (invoked with `model: "haiku"` so
+the expensive main model only orchestrates), and a deterministic merge script
+writes them back — no model in the write path. Input → output: empty `msgstr` in
+`locales/{locale}/www.po` → filled `msgstr`.
+
+**Announce at start:** "Using the translate skill — filling missing .po translations via Haiku subagents."
+
+Scope: all target locales at once (locales from `lingui.config.js` minus source `en`).
+Never overwrites an existing translation — only empty `msgstr` are touched.
+
+## Step 1 — Extract missing translations into chunked jobs
+
+```bash
+npm run lingui:extract                                              # refresh catalogs from source strings
+node .claude/skills/translate/scripts/extract-missing.mjs          # scan → chunk jobs
+```
+
+Read the printed summary. It prints total missing, chunk count, and per-locale
+counts, then writes `.claude/scratch/translate/manifest.json` plus one input file per
+chunk under `.claude/scratch/translate/in/`.
+
+- If the output contains `NOTHING_TO_TRANSLATE` → **STOP**, report "no missing
+  translations", skip to nothing. Do not run later steps.
+
+## Step 2 — Start the live progress watcher, then fan out subagents
+
+First launch the background watcher **once** — it ticks every 10s independently of
+the main loop. Use the `Bash` tool with `run_in_background: true`:
+
+```bash
+node .claude/skills/translate/scripts/progress.mjs --watch
+```
+
+It reports `chunks done/total · strings done/total (%)` with a per-locale
+breakdown, updating as each subagent writes its `out/` file.
+
+Then read `.claude/scratch/translate/manifest.json` — an array of
+`{ chunk, in, out, locale, catalog, langLabel, count }`.
+
+For **every** entry, dispatch an `Agent` with **`model: "haiku"`**. Dispatch in
+batches of **up to 10 Agent calls per message** so they run concurrently.
+**After each batch returns, run a one-shot snapshot:**
+
+```bash
+node .claude/skills/translate/scripts/progress.mjs
+```
+
+Then send the next batch. Use this exact prompt, substituting the entry's `in`
+and `out` absolute paths:
+
+````text
+You are a professional software-localization translator for a manufacturing ERP website.
+
+Read the input file (JSON) at this absolute path:
+<manifest entry `in`>
+
+It is: { "locale", "langLabel", "catalog", "items": [ { "msgid", "note?" } ] }.
+Translate every item's `msgid` from English into the language named by `langLabel`.
+
+RULES — follow exactly:
+1. Preserve every placeholder EXACTLY: `{0}`, `{name}`, `{count}`, etc. Never
+   translate, rename, reorder-away, or drop a placeholder token.
+2. For ICU syntax like `{0, plural, one {…} other {…}}`, keep the structure,
+   keywords (`plural`, `select`, `one`, `other`, `=0`, `#`) and braces intact;
+   translate ONLY the human words inside each `{…}` branch.
+3. Preserve leading/trailing spaces, capitalization intent, and punctuation.
+4. Do NOT translate brand names, code identifiers, or placeholder variable names.
+5. Use `note` only as context for a placeholder; never include it in the output.
+
+OUTPUT — write ONLY a JSON object (create/overwrite) to this absolute path:
+<manifest entry `out`>
+
+It maps each input `msgid` (exact original English key, unchanged) to its
+translation, e.g. { "Add parts": "Ajouter des pièces", "{0} days": "{0} jours" }.
+Every input item must be a key. No commentary. Then reply only: DONE.
+````
+
+Do **NOT** trust the subagent's reply count — a subagent may misreport how many
+it wrote. The merge script in Step 3 is the source of truth.
+
+## Step 3 — Merge deterministically and verify
+
+```bash
+node .claude/skills/translate/scripts/merge-translations.mjs
+```
+
+Read its output:
+- `Merged: N filled, M unmatched` — `unmatched` means the model returned a key
+  that no longer matches an empty `msgid`; those are skipped safely.
+- `Remaining empty msgstr in targeted catalogs: R`.
+- `Missing/invalid chunk outputs` — chunks whose `out` file is absent or bad JSON.
+
+## Step 4 — Retry until dry (max 3 rounds total)
+
+| Situation | Action |
+|-----------|--------|
+| `Remaining` is `0` | Go to Step 5. |
+| `Remaining > 0` and rounds so far `< 3` | Re-run Step 1's `extract-missing.mjs` only (NOT `lingui:extract` again) — it regenerates jobs for just the still-empty entries — then redo subagent dispatch + snapshot + merge. Do **not** relaunch the watcher. |
+| `Remaining > 0` after 3 rounds | **STOP.** Report the residual count and locales still short. |
+
+If a whole locale keeps failing, lower the chunk size:
+`TRANSLATE_CHUNK_SIZE=15 node .claude/skills/translate/scripts/extract-missing.mjs`.
+
+## Step 5 — Finalize and report
+
+```bash
+touch .claude/scratch/translate/.done     # stops the background progress watcher
+npm run lingui:extract                    # re-extract to normalize catalog metadata
+```
+
+Do **not** run `lingui:compile` — `.mjs` compiled files are produced at build time.
+
+## Step 6 — Verify nothing is left
+
+Check for remaining empty `msgstr` entries:
+
+```bash
+node -e "
+const { readFileSync, readdirSync, existsSync } = require('fs');
+const { parsePo } = await import('./.claude/skills/translate/scripts/lib-po.mjs');
+// ... or simply grep
+" 2>/dev/null || grep -r 'msgstr ""' locales/*/www.po | grep -v 'msgid ""' | wc -l
+```
+
+A count of `0` means verified clean → Step 7.
+If non-zero after 3 rounds, report residual and STOP.
+
+## Step 7 — Clean up scratch (always, even on partial/failed runs)
+
+```bash
+rm -rf .claude/scratch/translate
+```
+
+Leaving `in/`, `out/`, and `manifest.json` behind risks stale chunks merging on
+the next run.
+
+## Output
+
+Filled `msgstr` values in `locales/{locale}/www.po`. Commit only if the user asks,
+via `/check-and-commit`. Scratch under `.claude/scratch/translate/` is disposable.
+
+## Done when
+- [ ] `merge-translations.mjs` reports `Remaining empty msgstr ... : 0` (or residual reported after 3 rounds).
+- [ ] `npm run lingui:extract` has run to normalize.
+- [ ] Only `msgstr` lines changed in the `.po` diff.
+- [ ] `.claude/scratch/translate` has been removed.
+
+## Failure → action
+| Symptom | Action |
+|---------|--------|
+| `extract-missing.mjs` errors reading config | Confirm `lingui.config.js` still defines a `locales` array. |
+| Merge shows many `unmatched` | The model rewrote keys. Re-run with smaller `TRANSLATE_CHUNK_SIZE`. |
+| A subagent dies / returns no file | That chunk's `out` is listed as missing; next retry round re-dispatches only still-empty entries. |

--- a/.claude/skills/translate/scripts/extract-missing.mjs
+++ b/.claude/skills/translate/scripts/extract-missing.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// Step 1 of /translate. Scans every committed .po catalog for empty msgstr
+// entries and writes deterministic, chunked translation jobs for cheap-model
+// subagents to fill.
+//
+// Outputs (all under .claude/scratch/translate/, gitignored):
+//   in/{n}.json        one chunk of msgids to translate (subagent INPUT)
+//   manifest.json      list of {in,out,locale,catalog,langLabel,count}
+//   (subagents write out/{n}.json — this script only creates in/ + manifest)
+//
+// Locale scope: locales from lingui.config.js, minus the source locale "en".
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync } from "node:fs";
+import { parsePo, readLocaleConfig } from "./lib-po.mjs";
+
+const REPO = process.cwd();
+const CONFIG = `${REPO}/lingui.config.js`;
+const LOCALES_DIR = `${REPO}/locales`;
+const OUT_DIR = `${REPO}/.claude/scratch/translate`;
+const CATALOG = "www"; // single catalog for the www repo
+const CHUNK_SIZE = Number(process.env.TRANSLATE_CHUNK_SIZE || 40);
+
+const { codes, labels } = readLocaleConfig(CONFIG, readFileSync);
+const targets = codes.filter((c) => c !== "en");
+
+// Fresh scratch each run so stale chunks never merge.
+rmSync(OUT_DIR, { recursive: true, force: true });
+mkdirSync(`${OUT_DIR}/in`, { recursive: true });
+mkdirSync(`${OUT_DIR}/out`, { recursive: true });
+
+const manifest = [];
+let chunkNo = 0;
+let totalMissing = 0;
+
+for (const locale of targets) {
+  const langLabel = labels[locale] || locale;
+  const po = `${LOCALES_DIR}/${locale}/${CATALOG}.po`;
+  if (!existsSync(po)) continue;
+  const { entries } = parsePo(readFileSync(po, "utf8"));
+  const missing = entries.filter((e) => e.msgid !== "" && e.msgstr === "");
+  if (missing.length === 0) continue;
+  totalMissing += missing.length;
+  for (let i = 0; i < missing.length; i += CHUNK_SIZE) {
+    const slice = missing.slice(i, i + CHUNK_SIZE);
+    const inPath = `${OUT_DIR}/in/${chunkNo}.json`;
+    const outPath = `${OUT_DIR}/out/${chunkNo}.json`;
+    writeFileSync(
+      inPath,
+      JSON.stringify(
+        {
+          locale,
+          langLabel,
+          catalog: CATALOG,
+          items: slice.map((e) => ({
+            msgid: e.msgid,
+            note: e.comments.filter((c) => c.startsWith("#.")).join(" ").trim() || undefined,
+          })),
+        },
+        null,
+        2,
+      ),
+    );
+    manifest.push({ chunk: chunkNo, in: inPath, out: outPath, locale, catalog: CATALOG, langLabel, count: slice.length });
+    chunkNo++;
+  }
+}
+
+writeFileSync(`${OUT_DIR}/manifest.json`, JSON.stringify(manifest, null, 2));
+
+const byLocale = {};
+for (const m of manifest) byLocale[m.locale] = (byLocale[m.locale] || 0) + m.count;
+console.log(`Missing translations: ${totalMissing} across ${targets.length} locales`);
+console.log(`Chunks: ${manifest.length} (size ${CHUNK_SIZE}) → ${OUT_DIR}/manifest.json`);
+for (const [loc, n] of Object.entries(byLocale)) console.log(`  ${loc}: ${n}`);
+if (totalMissing === 0) console.log("NOTHING_TO_TRANSLATE");

--- a/.claude/skills/translate/scripts/lib-po.mjs
+++ b/.claude/skills/translate/scripts/lib-po.mjs
@@ -1,0 +1,79 @@
+// Shared .po parsing helpers for the /translate skill.
+// A .po entry is: optional comment lines (#...), a msgid (one or more quoted
+// lines), then a msgstr (one or more quoted lines). Values are the quoted
+// segments concatenated, with PO escape sequences decoded.
+
+const UNESCAPE = { '"': '"', "\\": "\\", n: "\n", t: "\t", r: "\r" };
+
+export function unescapePo(s) {
+  return s.replace(/\\(["\\ntr])/g, (_m, c) => UNESCAPE[c]);
+}
+
+export function escapePo(s) {
+  return s
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\t/g, "\\t")
+    .replace(/\r/g, "\\r");
+}
+
+function stripQuotes(q) {
+  const m = q.match(/^"([\s\S]*)"$/);
+  return m ? m[1] : "";
+}
+
+// Parse into { lines, entries }. Each entry: { comments[], msgid, msgstr,
+// msgstrLineIndex, msgstrLineCount }. Line indices point into `lines` so a
+// caller can rewrite a msgstr in place and re-join.
+export function parsePo(text) {
+  const lines = text.split("\n");
+  const entries = [];
+  let i = 0;
+  while (i < lines.length) {
+    const comments = [];
+    while (i < lines.length && lines[i].startsWith("#")) comments.push(lines[i++]);
+    if (i >= lines.length) break;
+    if (!lines[i].startsWith("msgid ")) {
+      i++;
+      continue;
+    }
+    const msgidQ = [lines[i].slice("msgid ".length)];
+    i++;
+    while (i < lines.length && lines[i].startsWith('"')) msgidQ.push(lines[i++]);
+    if (i >= lines.length || !lines[i].startsWith("msgstr ")) continue;
+    const msgstrLineIndex = i;
+    const msgstrQ = [lines[i].slice("msgstr ".length)];
+    i++;
+    while (i < lines.length && lines[i].startsWith('"')) msgstrQ.push(lines[i++]);
+    entries.push({
+      comments,
+      msgid: msgidQ.map((q) => unescapePo(stripQuotes(q))).join(""),
+      msgstr: msgstrQ.map((q) => unescapePo(stripQuotes(q))).join(""),
+      msgstrLineIndex,
+      msgstrLineCount: msgstrQ.length,
+    });
+  }
+  return { lines, entries };
+}
+
+// Read locales from lingui.config.js in the repo root.
+// Returns { codes: string[], labels: Record<string, string> }.
+// Labels fall back to the locale code when no native name is known.
+const NATIVE_LABELS = {
+  en: "English", de: "Deutsch", es: "Español", fr: "Français",
+  it: "Italiano", ja: "日本語", zh: "中文", pl: "Polski",
+  pt: "Português", ru: "Русский", hi: "हिन्दी", nl: "Nederlands",
+  tr: "Türkçe", ko: "한국어",
+};
+
+export function readLocaleConfig(configPath, readFileSync) {
+  const src = readFileSync(configPath, "utf8");
+  // Pull the locales array from lingui.config.js
+  const listMatch = src.match(/locales\s*:\s*\[([\s\S]*?)\]/);
+  if (!listMatch) throw new Error(`Could not find locales array in ${configPath}`);
+  const codes = [...listMatch[1].matchAll(/"([a-z-]+)"/g)].map((m) => m[1]);
+  const labels = {};
+  for (const c of codes) labels[c] = NATIVE_LABELS[c] || c;
+  return { codes, labels };
+}

--- a/.claude/skills/translate/scripts/merge-translations.mjs
+++ b/.claude/skills/translate/scripts/merge-translations.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Final step of /translate. Reads the chunk outputs produced by the cheap-model
+// subagents and writes each translation into the matching empty msgstr in the
+// .po files. Deterministic: no model in the write path, only exact msgid match,
+// and only empty msgstr are ever touched (existing translations are never
+// overwritten). Reports matched / unmatched / still-missing counts.
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { escapePo, parsePo } from "./lib-po.mjs";
+
+const REPO = process.cwd();
+const OUT_DIR = `${REPO}/.claude/scratch/translate`;
+const LOCALES_DIR = `${REPO}/locales`;
+const MANIFEST = `${OUT_DIR}/manifest.json`;
+
+if (!existsSync(MANIFEST)) {
+  console.error(`No manifest at ${MANIFEST}. Run extract-missing.mjs first.`);
+  process.exit(1);
+}
+const manifest = JSON.parse(readFileSync(MANIFEST, "utf8"));
+
+// Merge all chunk outputs for a given locale against its .po once.
+const byPo = {};
+for (const m of manifest) {
+  const key = `${m.locale}/${m.catalog}`;
+  (byPo[key] ||= { locale: m.locale, catalog: m.catalog, outs: [] }).outs.push(m.out);
+}
+
+let matched = 0;
+let unmatched = 0;
+const missingChunks = [];
+
+for (const { locale, catalog, outs } of Object.values(byPo)) {
+  const translations = {};
+  for (const out of outs) {
+    if (!existsSync(out)) {
+      missingChunks.push(out);
+      continue;
+    }
+    try {
+      Object.assign(translations, JSON.parse(readFileSync(out, "utf8")));
+    } catch {
+      missingChunks.push(`${out} (invalid JSON)`);
+    }
+  }
+  if (Object.keys(translations).length === 0) continue;
+
+  const po = `${LOCALES_DIR}/${locale}/${catalog}.po`;
+  const { lines, entries } = parsePo(readFileSync(po, "utf8"));
+  const targeted = new Set();
+  for (const e of entries) {
+    if (e.msgid === "" || e.msgstr !== "") continue; // only fill empties
+    const t = translations[e.msgid];
+    if (t === undefined || t === "") continue;
+    if (e.msgstrLineCount !== 1) continue; // empty msgstr is always one line
+    lines[e.msgstrLineIndex] = `msgstr "${escapePo(t)}"`;
+    matched++;
+    targeted.add(e.msgid);
+  }
+  for (const k of Object.keys(translations)) if (!targeted.has(k)) unmatched++;
+  writeFileSync(po, lines.join("\n"));
+}
+
+// Recount remaining empties across the targeted catalogs.
+let remaining = 0;
+for (const { locale, catalog } of Object.values(byPo)) {
+  const { entries } = parsePo(readFileSync(`${LOCALES_DIR}/${locale}/${catalog}.po`, "utf8"));
+  remaining += entries.filter((e) => e.msgid !== "" && e.msgstr === "").length;
+}
+
+console.log(`Merged: ${matched} filled, ${unmatched} unmatched (key mismatch)`);
+console.log(`Remaining empty msgstr in targeted catalogs: ${remaining}`);
+if (missingChunks.length) {
+  console.log(`Missing/invalid chunk outputs (${missingChunks.length}):`);
+  for (const c of missingChunks) console.log(`  ${c}`);
+}
+if (remaining > 0) console.log("INCOMPLETE — re-run /translate to fill the rest");

--- a/.claude/skills/translate/scripts/progress.mjs
+++ b/.claude/skills/translate/scripts/progress.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Live progress for /translate. Reads the manifest + the out/ chunk files that
+// Haiku subagents write as they finish, and reports how many chunks / strings
+// are done, overall and per locale.
+//
+//   node progress.mjs            one-shot snapshot (print after each batch)
+//   node progress.mjs --watch    tick every 10s until .done marker (background)
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+
+const REPO = process.cwd();
+const DIR = `${REPO}/.claude/scratch/translate`;
+const MANIFEST = `${DIR}/manifest.json`;
+const DONE_MARKER = `${DIR}/.done`;
+const watch = process.argv.includes("--watch");
+const INTERVAL_MS = Number(process.env.TRANSLATE_PROGRESS_INTERVAL || 10) * 1000;
+const MAX_MS = 45 * 60 * 1000; // safety stop
+
+function bar(frac, width = 24) {
+  const n = Math.max(0, Math.min(width, Math.round(frac * width)));
+  return `[${"#".repeat(n)}${"-".repeat(width - n)}]`;
+}
+
+function snapshot() {
+  if (!existsSync(MANIFEST)) return "[progress] waiting for manifest…";
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(MANIFEST, "utf8"));
+  } catch {
+    return "[progress] manifest being rewritten…";
+  }
+  const outFiles = existsSync(`${DIR}/out`) ? new Set(readdirSync(`${DIR}/out`)) : new Set();
+  const exp = {};
+  const got = {};
+  let chunksDone = 0;
+  let strDone = 0;
+  let strExp = 0;
+  for (const m of manifest) {
+    exp[m.locale] = (exp[m.locale] || 0) + m.count;
+    got[m.locale] = got[m.locale] || 0;
+    strExp += m.count;
+    const fname = `${m.chunk}.json`;
+    if (outFiles.has(fname)) {
+      try {
+        const keys = Object.keys(JSON.parse(readFileSync(`${DIR}/out/${fname}`, "utf8"))).length;
+        chunksDone++;
+        strDone += keys;
+        got[m.locale] += keys;
+      } catch {
+        // half-written file this tick; counts next tick
+      }
+    }
+  }
+  const frac = strExp ? strDone / strExp : 1;
+  const perLocale = Object.keys(exp)
+    .map((l) => `${l} ${got[l]}/${exp[l]}`)
+    .join(" · ");
+  const ts = new Date().toISOString().slice(11, 19);
+  return (
+    `[progress ${ts}] ${bar(frac)} chunks ${chunksDone}/${manifest.length} · ` +
+    `strings ${strDone}/${strExp} (${Math.round(frac * 100)}%)\n            ${perLocale}`
+  );
+}
+
+if (!watch) {
+  console.log(snapshot());
+} else {
+  const start = Date.now();
+  console.log(snapshot());
+  const timer = setInterval(() => {
+    if (existsSync(DONE_MARKER) || Date.now() - start > MAX_MS) {
+      console.log(snapshot());
+      console.log("[progress] done.");
+      clearInterval(timer);
+      return;
+    }
+    console.log(snapshot());
+  }, INTERVAL_MS);
+}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ app/lib/static-blog-data.ts
 
 opencode.json
 .mcp.json
+# translate skill scratch
+.claude/scratch/


### PR DESCRIPTION
Ports the `translate` and `check-and-commit` skills from `crbnos/carbon` into this repo under `.claude/skills/`, adapted for the www repo structure.

## What's included

### `/translate`
- Fans missing `.po` translations out to cheap Haiku subagents, merges back deterministically
- Adapted for www's single `locales/{locale}/www.po` catalog (vs carbon's multi-catalog structure)
- Reads locale list from `lingui.config.js` directly
- Scripts: `extract-missing.mjs`, `merge-translations.mjs`, `progress.mjs`, `lib-po.mjs`

### `/check-and-commit`
- Pre-commit gate: typecheck → build → i18n (if UI/locale files changed)
- Calls `/translate` automatically when `I18N_RELEVANT`
- Explicit `git add` only — never `git add -A`

### `.gitignore`
- Adds `.claude/scratch/` to ignore translate's temporary chunk files