### PR TITLE
Make MCP Docs the primary CTA in developers section

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1065,21 +1065,21 @@ function Agents() {
 					<div className="flex flex-wrap gap-3">
 						<Button asChild variant="accent" size="cta">
 							<a
-								href="https://docs.carbon.ms/api-reference"
-								target="_blank"
-								rel="noopener"
-							>
-								<Trans>API Docs</Trans>
-								<Book />
-							</a>
-						</Button>
-						<Button asChild variant="accentOutline" size="cta">
-							<a
 								href="https://docs.carbon.ms/mcp"
 								target="_blank"
 								rel="noopener"
 							>
 								<Trans>MCP Docs</Trans>
+								<Book />
+							</a>
+						</Button>
+						<Button asChild variant="accentOutline" size="cta">
+							<a
+								href="https://docs.carbon.ms/api-reference"
+								target="_blank"
+								rel="noopener"
+							>
+								<Trans>API Docs</Trans>
 								<ChevronRight />
 							</a>
 						</Button>

--- a/locales/de/www.po
+++ b/locales/de/www.po
@@ -108,7 +108,7 @@ msgstr "Animierte Montageanleitungen"
 msgid "API"
 msgstr "API"
 
-#: app/routes/_index.tsx:1072
+#: app/routes/_index.tsx:1082
 msgid "API Docs"
 msgstr "API-Dokumentation"
 
@@ -784,7 +784,7 @@ msgstr "Fertigungsausführung"
 msgid "Manufacturing-focused, GAAP accounting"
 msgstr "Herstellungsorientiert, GAAP-Buchhaltung"
 
-#: app/routes/_index.tsx:1082
+#: app/routes/_index.tsx:1072
 msgid "MCP Docs"
 msgstr "MCP Docs"
 

--- a/locales/en/www.po
+++ b/locales/en/www.po
@@ -108,7 +108,7 @@ msgstr "Animated assembly instructions"
 msgid "API"
 msgstr "API"
 
-#: app/routes/_index.tsx:1072
+#: app/routes/_index.tsx:1082
 msgid "API Docs"
 msgstr "API Docs"
 
@@ -784,7 +784,7 @@ msgstr "Manufacturing execution"
 msgid "Manufacturing-focused, GAAP accounting"
 msgstr "Manufacturing-focused, GAAP accounting"
 
-#: app/routes/_index.tsx:1082
+#: app/routes/_index.tsx:1072
 msgid "MCP Docs"
 msgstr "MCP Docs"
 

--- a/locales/es/www.po
+++ b/locales/es/www.po
@@ -108,7 +108,7 @@ msgstr "Instrucciones de ensamblaje animadas"
 msgid "API"
 msgstr "API"
 
-#: app/routes/_index.tsx:1072
+#: app/routes/_index.tsx:1082
 msgid "API Docs"
 msgstr "Documentación de API"
 
@@ -784,7 +784,7 @@ msgstr "Ejecución de manufactura"
 msgid "Manufacturing-focused, GAAP accounting"
 msgstr "Contabilidad enfocada en manufactura, GAAP"
 
-#: app/routes/_index.tsx:1082
+#: app/routes/_index.tsx:1072
 msgid "MCP Docs"
 msgstr "Documentación de MCP"
 

--- a/locales/fr/www.po
+++ b/locales/fr/www.po
@@ -108,7 +108,7 @@ msgstr "Instructions d'assemblage animées"
 msgid "API"
 msgstr "API"
 
-#: app/routes/_index.tsx:1072
+#: app/routes/_index.tsx:1082
 msgid "API Docs"
 msgstr "Documentation API"
 
@@ -784,7 +784,7 @@ msgstr "Exécution de la fabrication"
 msgid "Manufacturing-focused, GAAP accounting"
 msgstr "Comptabilité GAAP orientée vers la fabrication"
 
-#: app/routes/_index.tsx:1082
+#: app/routes/_index.tsx:1072
 msgid "MCP Docs"
 msgstr "Documentation MCP"
 

--- a/locales/hi/www.po
+++ b/locales/hi/www.po
@@ -108,7 +108,7 @@ msgstr "एनिमेटेड असेंबली निर्देश"
 msgid "API"
 msgstr "API"
 
-#: app/routes/_index.tsx:1072
+#: app/routes/_index.tsx:1082
 msgid "API Docs"
 msgstr "API डॉक्स"
 
@@ -784,7 +784,7 @@ msgstr "विनिर्माण निष्पादन"
 msgid "Manufacturing-focused, GAAP accounting"
 msgstr "विनिर्माण-केंद्रित, GAAP लेखांकन"
 
-#: app/routes/_index.tsx:1082
+#: app/routes/_index.tsx:1072
 msgid "MCP Docs"
 msgstr "MCP डॉक्स"
 

--- a/locales/it/www.po
+++ b/locales/it/www.po
@@ -108,7 +108,7 @@ msgstr "Istruzioni di assemblaggio animate"
 msgid "API"
 msgstr "API"
 
-#: app/routes/_index.tsx:1072
+#: app/routes/_index.tsx:1082
 msgid "API Docs"
 msgstr "Documentazione API"
 
@@ -784,7 +784,7 @@ msgstr "Esecuzione della produzione"
 msgid "Manufacturing-focused, GAAP accounting"
 msgstr "Focalizzato sulla produzione, contabilità GAAP"
 
-#: app/routes/_index.tsx:1082
+#: app/routes/_index.tsx:1072
 msgid "MCP Docs"
 msgstr "MCP Docs"
 

--- a/locales/ja/www.po
+++ b/locales/ja/www.po
@@ -108,7 +108,7 @@ msgstr "アニメーション付き組立指示"
 msgid "API"
 msgstr "API"
 
-#: app/routes/_index.tsx:1072
+#: app/routes/_index.tsx:1082
 msgid "API Docs"
 msgstr "API ドキュメント"
 
@@ -784,7 +784,7 @@ msgstr "製造実行"
 msgid "Manufacturing-focused, GAAP accounting"
 msgstr "製造重視、GAAP会計"
 
-#: app/routes/_index.tsx:1082
+#: app/routes/_index.tsx:1072
 msgid "MCP Docs"
 msgstr "MCP ドキュメント"
 

--- a/locales/ko/www.po
+++ b/locales/ko/www.po
@@ -108,7 +108,7 @@ msgstr "애니메이션 조립 지침"
 msgid "API"
 msgstr "API"
 
-#: app/routes/_index.tsx:1072
+#: app/routes/_index.tsx:1082
 msgid "API Docs"
 msgstr "API 문서"
 
@@ -784,7 +784,7 @@ msgstr "제조 실행"
 msgid "Manufacturing-focused, GAAP accounting"
 msgstr "제조 중심, GAAP 회계"
 
-#: app/routes/_index.tsx:1082
+#: app/routes/_index.tsx:1072
 msgid "MCP Docs"
 msgstr "MCP 문서"
 

--- a/locales/nl/www.po
+++ b/locales/nl/www.po
@@ -108,7 +108,7 @@ msgstr "Geanimeerde montagerichtlijnen"
 msgid "API"
 msgstr "API"
 
-#: app/routes/_index.tsx:1072
+#: app/routes/_index.tsx:1082
 msgid "API Docs"
 msgstr "API-documentatie"
 
@@ -784,7 +784,7 @@ msgstr "Productieuitvoering"
 msgid "Manufacturing-focused, GAAP accounting"
 msgstr "Productiegericht, GAAP-boekhouding"
 
-#: app/routes/_index.tsx:1082
+#: app/routes/_index.tsx:1072
 msgid "MCP Docs"
 msgstr "MCP Docs"
 

--- a/locales/pl/www.po
+++ b/locales/pl/www.po
@@ -108,7 +108,7 @@ msgstr "Animowane instrukcje montażu"
 msgid "API"
 msgstr "API"
 
-#: app/routes/_index.tsx:1072
+#: app/routes/_index.tsx:1082
 msgid "API Docs"
 msgstr "Dokumentacja API"
 
@@ -784,7 +784,7 @@ msgstr "Wykonanie produkcji"
 msgid "Manufacturing-focused, GAAP accounting"
 msgstr "Zorientowana na produkcję, rachunkowość GAAP"
 
-#: app/routes/_index.tsx:1082
+#: app/routes/_index.tsx:1072
 msgid "MCP Docs"
 msgstr "Dokumentacja MCP"
 

--- a/locales/pt/www.po
+++ b/locales/pt/www.po
@@ -108,7 +108,7 @@ msgstr "Instruções de montagem animadas"
 msgid "API"
 msgstr "API"
 
-#: app/routes/_index.tsx:1072
+#: app/routes/_index.tsx:1082
 msgid "API Docs"
 msgstr "Documentação da API"
 
@@ -784,7 +784,7 @@ msgstr "Execução de manufatura"
 msgid "Manufacturing-focused, GAAP accounting"
 msgstr "Focado em manufatura, contabilidade GAAP"
 
-#: app/routes/_index.tsx:1082
+#: app/routes/_index.tsx:1072
 msgid "MCP Docs"
 msgstr "Docs do MCP"
 

--- a/locales/ru/www.po
+++ b/locales/ru/www.po
@@ -108,7 +108,7 @@ msgstr "Анимированные инструкции по сборке"
 msgid "API"
 msgstr "API"
 
-#: app/routes/_index.tsx:1072
+#: app/routes/_index.tsx:1082
 msgid "API Docs"
 msgstr "Документация API"
 
@@ -784,7 +784,7 @@ msgstr "Выполнение производственных операций"
 msgid "Manufacturing-focused, GAAP accounting"
 msgstr "Ориентирован на производство, учет по GAAP"
 
-#: app/routes/_index.tsx:1082
+#: app/routes/_index.tsx:1072
 msgid "MCP Docs"
 msgstr "Документация MCP"
 

--- a/locales/tr/www.po
+++ b/locales/tr/www.po
@@ -108,7 +108,7 @@ msgstr "Animasyonlu montaj talimatları"
 msgid "API"
 msgstr "API"
 
-#: app/routes/_index.tsx:1072
+#: app/routes/_index.tsx:1082
 msgid "API Docs"
 msgstr "API Dokümanları"
 
@@ -784,7 +784,7 @@ msgstr "İmalat yürütmesi"
 msgid "Manufacturing-focused, GAAP accounting"
 msgstr "İmalat odaklı, GAAP muhasebesi"
 
-#: app/routes/_index.tsx:1082
+#: app/routes/_index.tsx:1072
 msgid "MCP Docs"
 msgstr "MCP Belgeleri"
 

--- a/locales/zh/www.po
+++ b/locales/zh/www.po
@@ -108,7 +108,7 @@ msgstr "动画组装说明"
 msgid "API"
 msgstr "API"
 
-#: app/routes/_index.tsx:1072
+#: app/routes/_index.tsx:1082
 msgid "API Docs"
 msgstr "API 文档"
 
@@ -784,7 +784,7 @@ msgstr "制造执行"
 msgid "Manufacturing-focused, GAAP accounting"
 msgstr "以制造为中心，GAAP 会计"
 
-#: app/routes/_index.tsx:1082
+#: app/routes/_index.tsx:1072
 msgid "MCP Docs"
 msgstr "MCP 文档"
 


### PR DESCRIPTION
In the "An API for the entire organization." section of the homepage, swap the two documentation buttons so **MCP Docs** is now the primary (accent) button with the icon and **API Docs** is the secondary (outline) button. The lingui catalogs were regenerated by the pre-commit hook to reflect the updated button labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)